### PR TITLE
fix deprecation warning in `pandas_to_df`, add test, mv exports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CatBoost"
 uuid = "e2e10f9a-a85d-4fa9-b6b2-639a32100a12"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/src/CatBoost.jl
+++ b/src/CatBoost.jl
@@ -7,6 +7,20 @@ using OrderedCollections
 using Tables
 
 #####
+##### Exports
+#####
+
+export catboost
+
+export CatBoostRegressor, CatBoostClassifier
+export fit!, cv, predict, predict_proba
+export Pool
+export pandas_to_df
+
+# Datasets API.
+export load_dataset
+
+#####
 ##### _init_
 #####
 
@@ -137,9 +151,7 @@ function pandas_to_df(pandas_df::PyObject)
         ret = c isa PyObject ? PyAny(c) : c
         return ret isa Int ? ret + 1 : ret
     end
-    # Did the creators of PyCall seriously handle the conversion automatically? 
-    # What were they thinking?
-    df = DataFrame(Any[Array(pandas_df[c].values) for c in colnames], map(Symbol, colnames))
+    df = DataFrame(Any[Array(getproperty(pandas_df, c).values) for c in colnames], map(Symbol, colnames))
     return df
 end
 
@@ -152,18 +164,5 @@ function load_dataset(dataset_name::Symbol)
     return train, test
 end
 
-#####
-##### Exports
-#####
-
-export catboost
-
-export CatBoostRegressor, CatBoostClassifier
-export fit!, cv, predict, predict_proba
-export Pool
-export pandas_to_df
-
-# Datasets API.
-export load_dataset
 
 end # module

--- a/src/CatBoost.jl
+++ b/src/CatBoost.jl
@@ -151,7 +151,8 @@ function pandas_to_df(pandas_df::PyObject)
         ret = c isa PyObject ? PyAny(c) : c
         return ret isa Int ? ret + 1 : ret
     end
-    df = DataFrame(Any[Array(getproperty(pandas_df, c).values) for c in colnames], map(Symbol, colnames))
+    df = DataFrame(Any[Array(getproperty(pandas_df, c).values) for c in colnames],
+                   map(Symbol, colnames))
     return df
 end
 
@@ -163,6 +164,5 @@ function load_dataset(dataset_name::Symbol)
     train, test = getproperty(catboost_datasets, dataset_name)()
     return train, test
 end
-
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, CatBoost, DataFrames
+using Test, CatBoost, DataFrames, PyCall
 using Aqua
 
 EXAMPLES_DIR = joinpath(@__DIR__, "..", "examples")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Aqua
 EXAMPLES_DIR = joinpath(@__DIR__, "..", "examples")
 
 @testset "`to_pandas` and `pandas_to_df`" begin
-    df = DataFrame(floats = 0.5:0.5:3.0, ints=1:6)
+    df = DataFrame(; floats=0.5:0.5:3.0, ints=1:6)
     pd = CatBoost.to_pandas(df)
     @test pd isa PyObject
     df2 = pandas_to_df(pd)
@@ -19,6 +19,5 @@ end
         end
     end
 end
-
 
 Aqua.test_all(CatBoost; ambiguities=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,24 @@
-using Test, CatBoost, Aqua
+using Test, CatBoost, DataFrames
+using Aqua
 
 EXAMPLES_DIR = joinpath(@__DIR__, "..", "examples")
 
-for ex in readdir(EXAMPLES_DIR)
-    @testset "$ex" begin
-        # Just check the examples run, for now.
-        include(joinpath(EXAMPLES_DIR, ex))
+@testset "`to_pandas` and `pandas_to_df`" begin
+    df = DataFrame(floats = 0.5:0.5:3.0, ints=1:6)
+    pd = CatBoost.to_pandas(df)
+    @test pd isa PyObject
+    df2 = pandas_to_df(pd)
+    @test df2 == df
+end
+
+@testset "Examples" begin
+    for ex in readdir(EXAMPLES_DIR)
+        @testset "$ex" begin
+            # Just check the examples run, for now.
+            include(joinpath(EXAMPLES_DIR, ex))
+        end
     end
 end
+
 
 Aqua.test_all(CatBoost; ambiguities=false)


### PR DESCRIPTION
We were doing `pandas_df[c]` which is deprecated syntax for `getproperty(pandas_df, c)` apparently. Julia on 1.5+ doesn't show deprecation warnings except during `Pkg.test` and our examples are kind of verbose so maybe we missed it there (or maybe we didn't hit this method).